### PR TITLE
Specify the content type of uploads to avoid http 406

### DIFF
--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -86,13 +86,13 @@ Redmine.prototype.encodeURL = function(path, params) {
  * request - request url from Redmine
  */
 Redmine.prototype.request = function(method, path, params, callback) {
-  var isUpload = method == '/uploads.json';
+  var isUpload = path == '/uploads.json';
   var opts = {
     method: method,
     qs: method === 'GET' ? params : undefined,
     body: method === 'PUT' || method === 'POST' ? params : undefined,
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': isUpload ? 'application/octet-stream' : 'application:json'
     },
     // auth: { user: this.username, pass: this.password },
     json: !isUpload


### PR DESCRIPTION
From the doc : `The request body should be the content of the file you want to attach and the Content-Type header must be set to application/octet-stream (otherwise you'll get a 406 Not Acceptable response).`